### PR TITLE
refactor: 💡 textのほうとformatをそろえた

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,7 +2,6 @@
   "$schema": "https://json.schemastore.org/prettierrc",
   "semi": false,
   "tabWidth": 2,
-  "singleQuote": true,
   "printWidth": 100,
   "trailingComma": "none"
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import HelloWorld from './components/HelloWorld.vue'
-import TheWelcome from './components/TheWelcome.vue'
+import HelloWorld from "./components/HelloWorld.vue"
+import TheWelcome from "./components/TheWelcome.vue"
 </script>
 
 <template>

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -64,8 +64,8 @@ body {
   background: var(--color-background);
   transition: color 0.5s, background-color 0.5s;
   line-height: 1.6;
-  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-    Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 15px;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,4 +1,4 @@
-@import './base.css';
+@import "./base.css";
 
 #app {
   max-width: 1280px;

--- a/src/components/TheWelcome.vue
+++ b/src/components/TheWelcome.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import WelcomeItem from './WelcomeItem.vue'
-import DocumentationIcon from './icons/IconDocumentation.vue'
-import ToolingIcon from './icons/IconTooling.vue'
-import EcosystemIcon from './icons/IconEcosystem.vue'
-import CommunityIcon from './icons/IconCommunity.vue'
-import SupportIcon from './icons/IconSupport.vue'
+import WelcomeItem from "./WelcomeItem.vue"
+import DocumentationIcon from "./icons/IconDocumentation.vue"
+import ToolingIcon from "./icons/IconTooling.vue"
+import EcosystemIcon from "./icons/IconEcosystem.vue"
+import CommunityIcon from "./icons/IconCommunity.vue"
+import SupportIcon from "./icons/IconSupport.vue"
 </script>
 
 <template>

--- a/src/components/WelcomeItem.vue
+++ b/src/components/WelcomeItem.vue
@@ -58,7 +58,7 @@ h3 {
   }
 
   .item:before {
-    content: ' ';
+    content: " ";
     border-left: 1px solid var(--color-border);
     position: absolute;
     left: 0;
@@ -67,7 +67,7 @@ h3 {
   }
 
   .item:after {
-    content: ' ';
+    content: " ";
     border-left: 1px solid var(--color-border);
     position: absolute;
     left: 0;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import './assets/main.css'
+import "./assets/main.css"
 
-import { createApp } from 'vue'
-import App from './App.vue'
+import { createApp } from "vue"
+import App from "./App.vue"
 
-createApp(App).mount('#app')
+createApp(App).mount("#app")


### PR DESCRIPTION
double quotationにしたのはそもそもJSとPython以外のほとんどは
`"" = string`
`'' = char`だから